### PR TITLE
Add SIG Release Issue Tempaltes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+about: Report a bug encountered while using Kubernetes release engineering tooling
+labels: kind/bug, sig/release, area/release-eng
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/
+-->
+
+#### What happened:
+
+#### What you expected to happen:
+
+#### How to reproduce it (as minimally and precisely as possible):
+
+#### Anything else we need to know?:
+
+#### Environment:
+
+- Cloud provider or hardware configuration:
+- OS (e.g: `cat /etc/os-release`):
+- Kernel (e.g. `uname -a`):
+- Others:

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Suggest a feature for the Kubernetes release engineering tooling
+labels: kind/feature, sig/release, area/release-eng
+
+---
+<!-- Please only use this template for submitting feature requests -->
+
+#### What would you like to be added:
+
+#### Why is this needed:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
+- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
+https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
+- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+-->
+
+#### What type of PR is this?
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
+
+#### What this PR does / why we need it:
+
+#### Which issue(s) this PR fixes:
+
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+
+Fixes #
+
+or
+
+None
+-->
+
+#### Special notes for your reviewer:
+
+#### Does this PR introduce a user-facing change?
+
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+
+For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
+
+```release-note
+
+```


### PR DESCRIPTION
This Pull request adds the standard SIG Release issue
and PR templates to the tejolote repository.

/cc @cpanato @saschagrunert @jeremyrickard @Verolop 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>