### PR TITLE
increase timeout and machinetype

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,9 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 ---
-timeout: 3600s
+timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: 'N1_HIGHCPU_8'
 steps:
   - name: gcr.io/cloud-builders/git
     dir: "go/src/sigs.k8s.io"


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- increase timeout and machinetype

job failure due timeout: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-tejolote-push-images/1591159827977998336

/assign @saschagrunert @puerco @Verolop @xmudrii @palnabarun 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
