### PR TITLE
bump release-utils to 0.7.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/uwu-tools/magex v0.10.0
 	golang.org/x/sync v0.4.0
 	sigs.k8s.io/release-sdk v0.10.3
-	sigs.k8s.io/release-utils v0.7.5
+	sigs.k8s.io/release-utils v0.7.6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1460,8 +1460,8 @@ sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMm
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/release-sdk v0.10.3 h1:OUDWndR0jXex7w1g/y2TI2TDmzJB0u1AFH4U8he/WAE=
 sigs.k8s.io/release-sdk v0.10.3/go.mod h1:EBZWXznKbtE6XHsdsB5lx+eGCv4gW+TuHJmnev7i//8=
-sigs.k8s.io/release-utils v0.7.5 h1:0DYUWILqT0rirJ+8Vrp+Fr8jG8Q32ejFnulkahOvEao=
-sigs.k8s.io/release-utils v0.7.5/go.mod h1:GZGWmbINwsLGKsoZKTeWUGp4F+Rbwhq4XDtJ45N+dLw=
+sigs.k8s.io/release-utils v0.7.6 h1:mQxQRAIulbyz6y7eOCzklAelcpYjBj8MMGFcxNnyqto=
+sigs.k8s.io/release-utils v0.7.6/go.mod h1:GZGWmbINwsLGKsoZKTeWUGp4F+Rbwhq4XDtJ45N+dLw=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/magefile.go
+++ b/magefile.go
@@ -77,7 +77,7 @@ func Verify() error {
 	}
 
 	fmt.Println("Running go module linter...")
-	if err := mage.VerifyGoMod(scriptDir); err != nil {
+	if err := mage.VerifyGoMod(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

- bump release-utils to 0.7.6
/assign @Verolop @saschagrunert @xmudrii 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
bump release-utils to 0.7.6
```
