### PR TITLE
add gh job to run golangcilint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: '1.21'
+          check-latest: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        with:
+          version: v1.55
+          args: --timeout=5m --verbose

--- a/magefile.go
+++ b/magefile.go
@@ -81,12 +81,16 @@ func Verify() error {
 		return err
 	}
 
-	fmt.Println("Running golangci-lint...")
-	if err := mage.RunGolangCILint("", false); err != nil {
+	if err := Build(); err != nil {
 		return err
 	}
 
-	if err := Build(); err != nil {
+	return nil
+}
+
+func GolangCILint() error {
+	fmt.Println("Running golangci-lint...")
+	if err := mage.RunGolangCILint("", false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- add gh job to run golangcilint

some pre-submits seem to be stuck running golangcilint, and running in gh action is easier and free :)


/assign @ameukam @xmudrii @puerco 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add gh job to run golangcilint
```
