### PR TITLE
Support SLSA v1 Attestations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/uwu-tools/magex v0.10.1
 	golang.org/x/sync v0.16.0
 	google.golang.org/api v0.242.0
+	google.golang.org/protobuf v1.36.6
 	sigs.k8s.io/bom v0.6.0
 	sigs.k8s.io/release-sdk v0.12.3
 	sigs.k8s.io/release-utils v0.12.0
@@ -260,7 +261,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/grpc v1.73.0 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -20,11 +20,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"time"
 
-	v1 "github.com/in-toto/attestation/go/v1"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 )
 
@@ -57,73 +54,6 @@ func (att *Attestation) SLSAv1() *Attestation {
 	return att
 }
 
-// NewSLSAPredicate returns a new SLSA predicate fully initialized
-func NewSLSAPredicate() *SLSAPredicate {
-	predicate := &SLSAPredicate{
-		Builder: common.ProvenanceBuilder{
-			ID: "", // TODO: Read builder from trusted environment
-		},
-		BuildType: "",
-		Invocation: slsa.ProvenanceInvocation{
-			ConfigSource: slsa.ConfigSource{
-				URI:        "",
-				Digest:     map[string]string{},
-				EntryPoint: "",
-			},
-			Parameters:  nil,
-			Environment: nil,
-		},
-		BuildConfig: nil,
-		Metadata: &slsa.ProvenanceMetadata{
-			BuildInvocationID: "",
-			BuildStartedOn:    nil,
-			BuildFinishedOn:   nil,
-			Completeness: slsa.ProvenanceComplete{
-				Parameters:  true,
-				Environment: false,
-				Materials:   false,
-			},
-			Reproducible: false,
-		},
-		Materials: []common.ProvenanceMaterial{},
-	}
-
-	return predicate
-}
-
-func (pred *SLSAPredicate) SetBuilderID(id string) {
-	pred.Builder.ID = id
-}
-
-func (pred *SLSAPredicate) SetBuilderType(id string) {
-	pred.BuildType = id
-}
-
-func (pred *SLSAPredicate) SetInvocationID(id string) {
-	pred.Metadata.BuildInvocationID = id
-}
-
-func (pred *SLSAPredicate) SetConfigSource(src *v1.ResourceDescriptor) {
-	for algo, val := range src.GetDigest() {
-		pred.Invocation.ConfigSource.Digest[algo] = val
-	}
-	pred.Invocation.ConfigSource.URI = src.GetUri()
-}
-
-func (pred *SLSAPredicate) SetEntryPoint(ep string) {
-	pred.Invocation.ConfigSource.EntryPoint = ep
-}
-
-func (pred *SLSAPredicate) SetResolvedDependencies(deps []*v1.ResourceDescriptor) {
-	pred.Materials = []common.ProvenanceMaterial{}
-	for _, dep := range deps {
-		pred.Materials = append(pred.Materials, common.ProvenanceMaterial{
-			URI:    dep.GetUri(),
-			Digest: dep.GetDigest(),
-		})
-	}
-}
-
 func (att *Attestation) ToJSON() ([]byte, error) {
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
@@ -134,38 +64,4 @@ func (att *Attestation) ToJSON() ([]byte, error) {
 		return nil, fmt.Errorf("encoding spdx sbom: %w", err)
 	}
 	return b.Bytes(), nil
-}
-
-// AddMaterial add an entry to the materials
-func (pred *SLSAPredicate) AddDependency(dep *v1.ResourceDescriptor) {
-	if pred.Materials == nil {
-		pred.Materials = []common.ProvenanceMaterial{}
-	}
-	mat := common.ProvenanceMaterial{
-		URI:    dep.GetUri(),
-		Digest: dep.GetDigest(),
-	}
-	for i, m := range pred.Materials {
-		if m.URI == dep.GetUri() {
-			pred.Materials[i] = mat
-			return
-		}
-	}
-	pred.Materials = append(pred.Materials, mat)
-}
-
-func (pred *SLSAPredicate) SetBuildConfig(conf map[string]any) {
-	pred.BuildConfig = conf
-}
-
-func (pred *SLSAPredicate) SetInternalParameters(params map[string]any) {
-	pred.Invocation.Environment = params
-}
-
-func (pred *SLSAPredicate) SetStartedOn(d *time.Time) {
-	pred.Metadata.BuildStartedOn = d
-}
-
-func (pred *SLSAPredicate) SetFinishedOn(d *time.Time) {
-	pred.Metadata.BuildFinishedOn = d
 }

--- a/pkg/attestation/predicate.go
+++ b/pkg/attestation/predicate.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attestation
+
+import (
+	"time"
+
+	v1 "github.com/in-toto/attestation/go/v1"
+)
+
+type Predicate interface {
+	SetBuilderID(string)
+	SetBuilderType(string)
+	SetInvocationID(string)
+	SetConfigSource(*v1.ResourceDescriptor)
+	SetEntryPoint(string)
+	SetResolvedDependencies([]*v1.ResourceDescriptor)
+	SetInternalParameters(map[string]any)
+	AddDependency(*v1.ResourceDescriptor)
+	SetBuildConfig(map[string]any)
+	SetStartedOn(*time.Time)
+	SetFinishedOn(*time.Time)
+}

--- a/pkg/attestation/slsa_v02.go
+++ b/pkg/attestation/slsa_v02.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attestation
+
+import (
+	"time"
+
+	v1 "github.com/in-toto/attestation/go/v1"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+)
+
+// NewSLSAPredicate returns a new SLSA predicate fully initialized
+func NewSLSAPredicate() *SLSAPredicate {
+	predicate := &SLSAPredicate{
+		Builder: common.ProvenanceBuilder{
+			ID: "", // TODO: Read builder from trusted environment
+		},
+		BuildType: "",
+		Invocation: slsa.ProvenanceInvocation{
+			ConfigSource: slsa.ConfigSource{
+				URI:        "",
+				Digest:     map[string]string{},
+				EntryPoint: "",
+			},
+			Parameters:  nil,
+			Environment: nil,
+		},
+		BuildConfig: nil,
+		Metadata: &slsa.ProvenanceMetadata{
+			BuildInvocationID: "",
+			BuildStartedOn:    nil,
+			BuildFinishedOn:   nil,
+			Completeness: slsa.ProvenanceComplete{
+				Parameters:  true,
+				Environment: false,
+				Materials:   false,
+			},
+			Reproducible: false,
+		},
+		Materials: []common.ProvenanceMaterial{},
+	}
+
+	return predicate
+}
+
+func (pred *SLSAPredicate) SetBuilderID(id string) {
+	pred.Builder.ID = id
+}
+
+func (pred *SLSAPredicate) SetBuilderType(id string) {
+	pred.BuildType = id
+}
+
+func (pred *SLSAPredicate) SetInvocationID(id string) {
+	pred.Metadata.BuildInvocationID = id
+}
+
+func (pred *SLSAPredicate) SetConfigSource(src *v1.ResourceDescriptor) {
+	for algo, val := range src.GetDigest() {
+		pred.Invocation.ConfigSource.Digest[algo] = val
+	}
+	pred.Invocation.ConfigSource.URI = src.GetUri()
+}
+
+func (pred *SLSAPredicate) SetEntryPoint(ep string) {
+	pred.Invocation.ConfigSource.EntryPoint = ep
+}
+
+func (pred *SLSAPredicate) SetResolvedDependencies(deps []*v1.ResourceDescriptor) {
+	pred.Materials = []common.ProvenanceMaterial{}
+	for _, dep := range deps {
+		pred.Materials = append(pred.Materials, common.ProvenanceMaterial{
+			URI:    dep.GetUri(),
+			Digest: dep.GetDigest(),
+		})
+	}
+}
+
+// AddMaterial add an entry to the materials
+func (pred *SLSAPredicate) AddDependency(dep *v1.ResourceDescriptor) {
+	if pred.Materials == nil {
+		pred.Materials = []common.ProvenanceMaterial{}
+	}
+	mat := common.ProvenanceMaterial{
+		URI:    dep.GetUri(),
+		Digest: dep.GetDigest(),
+	}
+	for i, m := range pred.Materials {
+		if m.URI == dep.GetUri() {
+			pred.Materials[i] = mat
+			return
+		}
+	}
+	pred.Materials = append(pred.Materials, mat)
+}
+
+func (pred *SLSAPredicate) SetBuildConfig(conf map[string]any) {
+	pred.BuildConfig = conf
+}
+
+func (pred *SLSAPredicate) SetInternalParameters(params map[string]any) {
+	pred.Invocation.Environment = params
+}
+
+func (pred *SLSAPredicate) SetStartedOn(d *time.Time) {
+	pred.Metadata.BuildStartedOn = d
+}
+
+func (pred *SLSAPredicate) SetFinishedOn(d *time.Time) {
+	pred.Metadata.BuildFinishedOn = d
+}

--- a/pkg/attestation/slsa_v1.go
+++ b/pkg/attestation/slsa_v1.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attestation
+
+import (
+	"time"
+
+	slsa1 "github.com/in-toto/attestation/go/predicates/provenance/v1"
+	v1 "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type SLSAPredicateV1 struct {
+	slsa1.Provenance
+}
+
+func NewSLSAV1Predicate() *SLSAPredicateV1 {
+	return &SLSAPredicateV1{
+		Provenance: slsa1.Provenance{
+			BuildDefinition: &slsa1.BuildDefinition{
+				BuildType: "",
+				ExternalParameters: &structpb.Struct{
+					Fields: map[string]*structpb.Value{},
+				},
+				InternalParameters: &structpb.Struct{
+					Fields: map[string]*structpb.Value{},
+				},
+				ResolvedDependencies: []*v1.ResourceDescriptor{},
+			},
+			RunDetails: &slsa1.RunDetails{
+				Builder: &slsa1.Builder{
+					Id:      "",
+					Version: map[string]string{},
+					// BuilderDependencies: []*v1.ResourceDescriptor{},
+				},
+				Metadata: &slsa1.BuildMetadata{
+					InvocationId: "",
+					StartedOn:    &timestamppb.Timestamp{},
+					FinishedOn:   &timestamppb.Timestamp{},
+				},
+				Byproducts: []*v1.ResourceDescriptor{},
+			},
+		},
+	}
+}
+
+func (pred *SLSAPredicateV1) SetBuilderID(id string) {
+	pred.RunDetails.Builder.Id = id
+}
+
+func (pred *SLSAPredicateV1) SetBuilderType(id string) {
+	pred.BuildDefinition.BuildType = id
+}
+
+func (pred *SLSAPredicateV1) SetInvocationID(id string) {
+	pred.RunDetails.Metadata.InvocationId = id
+}
+
+func (pred *SLSAPredicateV1) SetConfigSource(src *v1.ResourceDescriptor) {
+	lc8r := src.GetUri()
+	if h, ok := src.GetDigest()["sha1"]; ok && h != "" {
+		lc8r += "@" + h
+	}
+	pred.BuildDefinition.ExternalParameters.Fields["source"] = structpb.NewStringValue(lc8r)
+}
+
+func (pred *SLSAPredicateV1) SetEntryPoint(ep string) {
+	pred.BuildDefinition.ExternalParameters.Fields["entryPoint"] = structpb.NewStringValue(ep)
+}
+
+func (pred *SLSAPredicateV1) SetResolvedDependencies(deps []*v1.ResourceDescriptor) {
+	// Todo, here we need to add:
+	// {
+	//     "uri": old.invocation.configSource.uri,
+	//     "digest": old.invocation.configSource.digest,
+	// }
+	// Which now lives in external parameters plus other stuff used
+	// (see above)
+	pred.BuildDefinition.ResolvedDependencies = deps
+}
+
+// SetBuildConfig is deprecated in v1:
+//
+//	buildConfig: No longer inlined into the provenance. Instead, either:
+//	If the configuration is a top-level input, record its digest in
+//	externalParameters["config"].
+//
+//	Else if there is a known use case for knowing the exact resolved build
+//	configuration, record its digest in byproducts. An example use case
+//	might be someone who wishes to parse the configuration to look for bad
+//	patterns, such as curl | bash.
+//
+//	Else omit it.
+func (pred *SLSAPredicateV1) SetBuildConfig(conf map[string]any) {}
+
+func (pred *SLSAPredicateV1) SetInternalParameters(params map[string]any) {
+	s, err := structpb.NewStruct(params)
+	if err != nil {
+		return
+	}
+	pred.BuildDefinition.InternalParameters = s
+}
+
+func (pred *SLSAPredicateV1) AddDependency(dep *v1.ResourceDescriptor) {
+	pred.BuildDefinition.ResolvedDependencies = append(pred.BuildDefinition.ResolvedDependencies, dep)
+}
+
+func (pred *SLSAPredicateV1) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		Multiline: true,
+		Indent:    "  ",
+	}.Marshal(pred)
+}
+
+func (pred *SLSAPredicateV1) SetStartedOn(d *time.Time) {
+	if d == nil {
+		pred.RunDetails.Metadata.StartedOn = nil
+		return
+	}
+	pred.RunDetails.Metadata.StartedOn = timestamppb.New(*d)
+}
+
+func (pred *SLSAPredicateV1) SetFinishedOn(d *time.Time) {
+	if d == nil {
+		pred.RunDetails.Metadata.FinishedOn = nil
+		return
+	}
+	pred.RunDetails.Metadata.FinishedOn = timestamppb.New(*d)
+}

--- a/pkg/builder/driver/driver.go
+++ b/pkg/builder/driver/driver.go
@@ -34,7 +34,7 @@ const (
 type BuildSystem interface {
 	GetRun(string) (*run.Run, error)
 	RefreshRun(*run.Run) error
-	BuildPredicate(*run.Run, *attestation.SLSAPredicate) (*attestation.SLSAPredicate, error)
+	BuildPredicate(*run.Run, attestation.Predicate) (attestation.Predicate, error)
 	ArtifactStores() []store.Store
 }
 

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -29,19 +29,19 @@ type Artifact struct {
 }
 
 type Run struct {
-	ID              int64  `json:"id"`
-	Status          string `json:"status"`
-	Conclusion      string `json:"conclusion"`
-	HeadBranch      string `json:"head_branch"`
-	HeadSHA         string `json:"head_sha"`
-	Path            string `json:"path"`
-	RunNumber       int64  `json:"run_number"`
-	WorkFlowID      int64  `json:"workflow_id"`
-	CreatedAt       string `json:"created_at"`
-	UpdatedAt       string `json:"updated_at"`
-	LogsURL         string `json:"logs_url"`
-	Actor           Actor  `json:"actor"`
-	TriggeringActor Actor  `json:"triggering_actor"`
+	ID              int64      `json:"id"`
+	Status          string     `json:"status"`
+	Conclusion      string     `json:"conclusion"`
+	HeadBranch      string     `json:"head_branch"`
+	HeadSHA         string     `json:"head_sha"`
+	Path            string     `json:"path"`
+	RunNumber       int64      `json:"run_number"`
+	WorkFlowID      int64      `json:"workflow_id"`
+	CreatedAt       *time.Time `json:"created_at"`
+	UpdatedAt       *time.Time `json:"updated_at"`
+	LogsURL         string     `json:"logs_url"`
+	Actor           Actor      `json:"actor"`
+	TriggeringActor Actor      `json:"triggering_actor"`
 }
 
 type Actor struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds support for [SLSA Build provenance attestations v1.0](https://slsa.dev/spec/v1.0/provenance).

To support multiple formats, we now have a generic attestation predicate interface which is used throughout the watcher and two implementations (the classic SLSA v0.2 and the new v1 implementation).

In addition, the attest subcommand now supports a `--slsa` switch to control the SLSA version of the produced attestation. 

When running in wait mode (`tejolote start`) only v0.2 is supported as we need a more sophisticated parser that is version aware to be able to support v1.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

/cc @cpanato @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
Tejolote now supports SLSA v1 attestations. When running `tejolote attest` there is a new `--slsa` switch to control the attestation version.
```
