### PR TITLE
Set predicate types according to version

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -165,6 +165,7 @@ attestation but with ".storage-snap.json" appended.
 			}
 
 			att.Predicate = predicate
+			att.PredicateType = att.Predicate.Type()
 
 			att.Predicate.SetBuilderID(startAttestationOpts.builder)
 			att.Predicate.SetEntryPoint(startAttestationOpts.configSrcEntry)

--- a/pkg/attestation/attestation.go
+++ b/pkg/attestation/attestation.go
@@ -36,9 +36,8 @@ type (
 func New() *Attestation {
 	attestation := &Attestation{
 		StatementHeader: intoto.StatementHeader{
-			Type:          intoto.StatementInTotoV01,
-			PredicateType: slsa.PredicateSLSAProvenance,
-			Subject:       []intoto.Subject{},
+			Type:    intoto.StatementInTotoV01,
+			Subject: []intoto.Subject{},
 		},
 	}
 	return attestation
@@ -46,11 +45,13 @@ func New() *Attestation {
 
 func (att *Attestation) SLSA() *Attestation {
 	att.Predicate = NewSLSAPredicate()
+	att.PredicateType = att.Predicate.Type()
 	return att
 }
 
 func (att *Attestation) SLSAv1() *Attestation {
 	att.Predicate = NewSLSAV1Predicate()
+	att.PredicateType = att.Predicate.Type()
 	return att
 }
 

--- a/pkg/attestation/predicate.go
+++ b/pkg/attestation/predicate.go
@@ -34,4 +34,5 @@ type Predicate interface {
 	SetBuildConfig(map[string]any)
 	SetStartedOn(*time.Time)
 	SetFinishedOn(*time.Time)
+	Type() string
 }

--- a/pkg/attestation/slsa_v02.go
+++ b/pkg/attestation/slsa_v02.go
@@ -124,3 +124,7 @@ func (pred *SLSAPredicate) SetStartedOn(d *time.Time) {
 func (pred *SLSAPredicate) SetFinishedOn(d *time.Time) {
 	pred.Metadata.BuildFinishedOn = d
 }
+
+func (pred *SLSAPredicate) Type() string {
+	return "https://slsa.dev/provenance/v0.2"
+}

--- a/pkg/attestation/slsa_v1.go
+++ b/pkg/attestation/slsa_v1.go
@@ -143,3 +143,7 @@ func (pred *SLSAPredicateV1) SetFinishedOn(d *time.Time) {
 	}
 	pred.RunDetails.Metadata.FinishedOn = timestamppb.New(*d)
 }
+
+func (pred *SLSAPredicateV1) Type() string {
+	return "https://slsa.dev/provenance/v1"
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -162,13 +163,12 @@ func (w *Watcher) AttestRun(r *run.Run) (att *attestation.Attestation, err error
 			Name:   a.Path,
 			Digest: common.DigestSet{},
 		}
-		for a, v := range a.Checksum {
-			s.Digest[a] = v
-		}
+		maps.Copy(s.Digest, a.Checksum)
 		att.Subject = append(att.Subject, s)
 	}
 
 	att.Predicate = predicate
+	att.PredicateType = att.Predicate.Type()
 	return att, nil
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We now support SLSAv1 in addition to v02, but tejolote is not setting the predicate type correctly. This fixes it.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where tejolote was not setting the attestation predicate type
```
