### PR TITLE
bump min go to 1.25 and clean up ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,22 +8,32 @@ on:
     branches:
       - 'main'
   pull_request:
+    branches:
+      - 'main'
+
+permissions: {}
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
+          cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1
+          version: v2.4
           args: --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           check-latest: true
 
       - name: Install cosign

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,9 +6,14 @@ on:
       - 'main'
   pull_request:
 
+permissions: {}
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Check out code onto GOPATH
@@ -16,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           check-latest: true
 
       - name: Install GoReleaser

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/tejolote
 
-go 1.24.5
+go 1.25
 
 require (
 	chainguard.dev/apko v0.30.6


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup
/kind feature


#### What this PR does / why we need it:

- bump min go to 1.25 and clean up ci

need: https://github.com/kubernetes/test-infra/pull/35410


/assign @saschagrunert @xmudrii @puerco 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:



None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
bump min go to 1.25 and clean up ci
```
