### PR TITLE
Expose error details when building watcher fails

### DIFF
--- a/internal/cmd/attest.go
+++ b/internal/cmd/attest.go
@@ -85,7 +85,7 @@ where they came from.
 
 			w, err := watcher.New(args[0])
 			if err != nil {
-				return fmt.Errorf("building watcher")
+				return fmt.Errorf("building watcher: %w", err)
 			}
 
 			w.Builder.VCSURL = attestOpts.vcsurl


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Expose error details when building watcher fails

If building the watcher fails, it is difficult to debug without propagating the err to the user.

#### Which issue(s) this PR fixes:

None on file.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Expose error details when building watcher fails
```
