### PR TITLE
Fix release binary and introduce dockerfile to track go version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,14 +26,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(awk -F'[:@]' '/FROM golang/{print $2; exit}' Dockerfile.dev)" >> $GITHUB_ENV
+
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.25'
+          go-version: '${{ env.GOVERSION }}'
           check-latest: true
           cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.4
+          version: v2.5
           args: --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(awk -F'[:@]' '/FROM golang/{print $2; exit}' Dockerfile.dev)" >> $GITHUB_ENV
+
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.25'
+          go-version: '${{ env.GOVERSION }}'
           check-latest: true
+          cache: false
 
       - name: Install cosign
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,11 +18,17 @@ jobs:
     steps:
       - name: Check out code onto GOPATH
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(awk -F'[:@]' '/FROM golang/{print $2; exit}' Dockerfile.dev)" >> $GITHUB_ENV
 
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.25'
+          go-version: '${{ env.GOVERSION }}'
           check-latest: true
+          cache: false
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -39,4 +39,4 @@ jobs:
           args: buildBinariesSnapshot
 
       - name: check binary
-        run: ./dist/tejolote-amd64-linux version
+        run: ./dist/tejolote_linux_amd64_v1/tejolote version

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,8 +17,6 @@ gomod:
 builds:
   - id: tejolote
     main: ./cmd/tejolote
-    no_unique_dist_dir: true
-    binary: tejolote-{{ .Arch }}-{{ .Os }}
     goos:
       - darwin
       - linux
@@ -46,8 +44,9 @@ builds:
       - "{{ .Env.TEJOLOTE_LDFLAGS }}"
 
 archives:
-  - format: binary
-    name_template: tejolote-{{ .Arch }}-{{ .Os }}
+  - formats:
+      - binary
+    name_template: "{{ .ProjectName }}-{{ .Arch }}-{{ .Os }}"
     allow_different_binary_count: true
 
 signs:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,19 @@
+#
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is used to we scrap the go version and use in CI to get the latest go version
+# and we use dependabot to keep the go version up to date
+FROM golang:1.25.1


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

- fix release binary name
similar we did in https://github.com/kubernetes-sigs/bom/pull/549

- add dummy dockerfile to keep track the go version and use that in ci
with that we dont need to manually update the go version in the GH actions


/assign @saschagrunert @Verolop @xmudrii  
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- fix release binary name
- add dummy dockerfile to keep track the go version and use that in ci
```
