### PR TITLE
Improve dependency support, better help

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -29,9 +29,9 @@ import (
 )
 
 type Builder struct {
-	SpecURL string
-	VCSURL  string
-	driver  driver.BuildSystem
+	SpecURL        string
+	DependencyURIs []string
+	driver         driver.BuildSystem
 }
 
 // New returns a new builder loaded with the driver derived from
@@ -64,21 +64,22 @@ func (b *Builder) RefreshRun(r *run.Run) error {
 	return b.driver.RefreshRun(r)
 }
 
+// BuildPredicate builds the data struct for the configured predicate
 func (b *Builder) BuildPredicate(r *run.Run, draft attestation.Predicate) (attestation.Predicate, error) {
 	pred, err := b.driver.BuildPredicate(r, draft)
 	if err != nil {
 		return nil, err
 	}
-	// If there is a VCS URL set, add it to the predicate
-	if b.VCSURL != "" {
-		uri := b.VCSURL
+
+	// Add any dependency URIs to the predicate
+	for _, uri := range b.DependencyURIs {
 		u, commit, ok := strings.Cut(uri, "@")
 		des := &v1.ResourceDescriptor{
 			Uri:    u,
 			Digest: map[string]string{},
 		}
 		if ok {
-			// The thing after the @ may not be a commit but we also want to
+			// The string after the @ may not be a commit, but we also want to
 			// support other, non VCS URIs, such as image references.
 
 			// Cut the string, to check if its a digest string

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -71,17 +71,30 @@ func (b *Builder) BuildPredicate(r *run.Run, draft attestation.Predicate) (attes
 	}
 	// If there is a VCS URL set, add it to the predicate
 	if b.VCSURL != "" {
-		u, commit, ok := strings.Cut(b.VCSURL, "@")
+		uri := b.VCSURL
+		u, commit, ok := strings.Cut(uri, "@")
 		des := &v1.ResourceDescriptor{
-			Uri: u,
+			Uri:    u,
+			Digest: map[string]string{},
 		}
 		if ok {
-			// The thing after the @ may not be a commit
-			if len(commit) == 40 {
+			// The thing after the @ may not be a commit but we also want to
+			// support other, non VCS URIs, such as image references.
+
+			// Cut the string, to check if its a digest string
+			first, rest, hasColon := strings.Cut(commit, ":")
+
+			switch {
+			case len(commit) == 40:
 				des.Digest["sha1"] = commit
 				des.Digest["gitCommit"] = commit
-			} else {
-				des.Uri = b.VCSURL
+				des.DownloadLocation = uri
+			case strings.HasPrefix(strings.ToLower(commit), "sha") && hasColon:
+				des.Digest[strings.ToLower(first)] = rest
+				des.DownloadLocation = uri
+			default:
+				// We don't know what the string is so just treat it as an uri
+				des.Uri = uri
 			}
 			pred.AddDependency(des)
 		} else {


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup
/kind documentation
/kind feature


#### What this PR does / why we need it:

The main prupose of this PR is to improve the dependency handling in the tejolote build.

We now support more types of dependencies through the CLI, in addition to VCS locators, tejolote will now also
parse simple OCI references and also handle bare urls.

Tejolote now supports more than one dependency through the CLI

The old `vcs-url` flag has been deprecated in favor of `--dependency` which is clearer and support more than one instance.  

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/assign @cpanato 
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
- Support for OCI reference-like string in the CLI 
- Tejolote now supports more than one dependency through the CLI
- The attest subcommand help has been much improved
- The `vcs-flag` has been deprecated in favor of `--dependency` (still works for compatibility)
```
