### PR TITLE
Detect own job automatically and add watch timeout

### DIFF
--- a/internal/cmd/attest.go
+++ b/internal/cmd/attest.go
@@ -23,11 +23,14 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/helpers"
+	"sigs.k8s.io/tejolote/pkg/github"
 	"sigs.k8s.io/tejolote/pkg/watcher"
 )
 
@@ -45,6 +48,7 @@ type attestOptions struct {
 	expandArtifacts  bool
 	artifactsFilter  string
 	envelope         string
+	watchTimeout     time.Duration
 }
 
 const (
@@ -52,6 +56,7 @@ const (
 	githubEnvVarActions = "GITHUB_ACTIONS"
 	githubEnvVarRepo    = "GITHUB_REPOSITORY"
 	githubEnvVarRunID   = "GITHUB_RUN_ID"
+	githubEnvVarRunner  = "RUNNER_NAME"
 )
 
 var (
@@ -181,20 +186,36 @@ build data and generates the provenance attestation.
 			w.Options.WatchJobs = attestOpts.watchJobs
 			w.Options.ExpandArtifacts = attestOpts.expandArtifacts
 			w.Options.ArtifactsFilter = attestOpts.artifactsFilter
+			w.Options.WatchTimeout = attestOpts.watchTimeout
 
 			// Auto detect if tejolote is running inside a GitHub Actions
-			// workflow and the spec URL points to the same run. The we automatically
-			// enable job-level watching to avoid deadlock where the run never
-			// completes because the attester job is part of it.
+			// workflow and the spec URL points to the same run. If so, switch to
+			// job-level watching and exclude our own job; otherwise the run could
+			// never complete because the attester job is part of it.
 			if isSameActionsRun(args[0]) {
-				// Get our own job name:
-				currentJob := os.Getenv(githubEnvVarJob)
-				if len(w.Options.WatchJobs) == 0 {
-					logrus.Infof("Same-run detected (job: %q), will watch all other jobs", currentJob)
-				} else {
-					logrus.Infof("Same-run detected (job: %q), watching specified jobs: %v", currentJob, w.Options.WatchJobs)
+				// $GITHUB_JOB is only the job *key*, but the jobs API reports the
+				// display name, so a job with a custom `name:` would not match.
+				// Resolve our own job via the runner name and exclude it by its
+				// real name, falling back to the key if detection is ambiguous.
+				excludeJob := os.Getenv(githubEnvVarJob)
+				repoParts := strings.SplitN(os.Getenv(githubEnvVarRepo), "/", 2)
+				runID, _ := strconv.ParseInt(os.Getenv(githubEnvVarRunID), 10, 64)
+				if len(repoParts) == 2 && runID != 0 {
+					job, derr := github.GetCurrentJob(repoParts[0], repoParts[1], runID, os.Getenv(githubEnvVarRunner))
+					switch {
+					case derr != nil:
+						logrus.Warnf("resolving own job, falling back to $GITHUB_JOB %q: %v", excludeJob, derr)
+					case job != nil:
+						excludeJob = job.GetName()
+						logrus.Infof("Same-run detected; excluding own job %q (id %d)", job.GetName(), job.GetID())
+					default:
+						logrus.Infof("Same-run detected; could not uniquely resolve own job, excluding by key %q", excludeJob)
+					}
 				}
-				w.Options.ExcludeJob = currentJob
+				if len(w.Options.WatchJobs) > 0 {
+					logrus.Infof("Watching specified jobs: %v", w.Options.WatchJobs)
+				}
+				w.Options.ExcludeJob = excludeJob
 			}
 
 			if !attestOpts.waitForBuild {
@@ -390,6 +411,13 @@ build data and generates the provenance attestation.
 		"watch-jobs",
 		[]string{},
 		"watch specific jobs (by name) instead of the entire run",
+	)
+
+	attestCmd.PersistentFlags().DurationVar(
+		&attestOpts.watchTimeout,
+		"watch-timeout",
+		20*time.Minute,
+		"max time to wait for the watched jobs/run to complete (0 = no timeout)",
 	)
 
 	parentCmd.AddCommand(attestCmd)

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -110,6 +110,38 @@ func GetRunJobs(org, repo string, runID int64) ([]*gogithub.WorkflowJob, error) 
 	return jobsResp.Jobs, nil
 }
 
+// GetCurrentJob returns the WorkflowJob for the job currently executing inside a
+// GitHub Actions runner.
+// It identifies the job by matching the given runner name (from the RUNNER_NAME
+// environment variable) against the run's jobs, restricted to those that are still
+// in progress. This uniquely identifies the caller even when the job definition
+// sets a custom name: GITHUB_JOB only exposes the job key, while the jobs API
+// reports the display name, so the two differ in that case. It returns (nil, nil)
+// when there is no unique match (eg when the RUNNER_NAME is unset or more than
+// one job in progress shares the runner name).
+func GetCurrentJob(org, repo string, runID int64, runnerName string) (*gogithub.WorkflowJob, error) {
+	if runnerName == "" {
+		return nil, nil
+	}
+
+	jobs, err := GetRunJobs(org, repo, runID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching run jobs: %w", err)
+	}
+
+	var match *gogithub.WorkflowJob
+	for _, job := range jobs {
+		if job.GetStatus() == "in_progress" && job.GetRunnerName() == runnerName {
+			if match != nil {
+				// Ambiguous: more than one in-progress job on this runner name.
+				return nil, nil
+			}
+			match = job
+		}
+	}
+	return match, nil
+}
+
 func Download(url string, f io.Writer) error {
 	agent := NewAgent()
 	return agent.GetToWriter(f, url)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -116,16 +116,20 @@ func (w *Watcher) Watch(r *run.Run) error {
 	}
 
 	for {
+		if err := w.Builder.RefreshRun(r); err != nil {
+			return fmt.Errorf("refreshing run data: %w", err)
+		}
+
 		if !r.IsRunning {
 			return nil
 		}
 
+		// Check the deadline only after a fresh refresh so a run that
+		// completed during the last poll interval is reported as done rather
+		// than as a timeout (mirrors watchJobs, which fetches fresh state
+		// before its own deadline check).
 		if !deadline.IsZero() && time.Now().After(deadline) {
 			return fmt.Errorf("timed out after %s waiting for run to complete", w.Options.WatchTimeout)
-		}
-
-		if err := w.Builder.RefreshRun(r); err != nil {
-			return fmt.Errorf("refreshing run data: %w", err)
 		}
 
 		time.Sleep(3 * time.Second)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -50,12 +50,13 @@ type Watcher struct {
 }
 
 type Options struct {
-	WaitForBuild    bool     // When true, the watcher will keep observing the run until it's done
-	SLSAVersion     string   // SLSA version for the attestation predicate
-	WatchJobs       []string // When set, watch these specific jobs instead of the whole run
-	ExcludeJob      string   // Job name to exclude from watching (typically the attester's own job)
-	ExpandArtifacts bool     // When true, unpack archive-wrapped artifacts (GitHub Actions) and hash contained files
-	ArtifactsFilter string   // When set, a glob matched against artifact names; only matching artifacts are collected
+	WaitForBuild    bool          // When true, the watcher will keep observing the run until it's done
+	SLSAVersion     string        // SLSA version for the attestation predicate
+	WatchJobs       []string      // When set, watch these specific jobs instead of the whole run
+	ExcludeJob      string        // Job name to exclude from watching (typically the attester's own job)
+	ExpandArtifacts bool          // When true, unpack archive-wrapped artifacts (GitHub Actions) and hash contained files
+	ArtifactsFilter string        // When set, a glob matched against artifact names; only matching artifacts are collected
+	WatchTimeout    time.Duration // Max time to wait for the run/jobs to complete (0 = no timeout)
 }
 
 func New(uri string) (w *Watcher, err error) {
@@ -101,15 +102,26 @@ func (w *Watcher) Watch(r *run.Run) error {
 		return nil
 	}
 
+	// Optional deadline so a stuck or mis-detected watch fails fast instead of
+	// polling forever (0 = wait indefinitely).
+	var deadline time.Time
+	if w.Options.WatchTimeout > 0 {
+		deadline = time.Now().Add(w.Options.WatchTimeout)
+	}
+
 	// If job-level watching is configured, watch the jobs instead of waiting
 	// for the runs.
 	if len(w.Options.WatchJobs) > 0 || w.Options.ExcludeJob != "" {
-		return w.watchJobs(r)
+		return w.watchJobs(r, deadline)
 	}
 
 	for {
 		if !r.IsRunning {
 			return nil
+		}
+
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for run to complete", w.Options.WatchTimeout)
 		}
 
 		if err := w.Builder.RefreshRun(r); err != nil {
@@ -122,7 +134,7 @@ func (w *Watcher) Watch(r *run.Run) error {
 
 // watchJobs polls the build system for the completion of specific jobs
 // rather than waiting for the entire run to complete.
-func (w *Watcher) watchJobs(r *run.Run) error {
+func (w *Watcher) watchJobs(r *run.Run, deadline time.Time) error {
 	jw, ok := w.Builder.Driver().(driver.JobWatcher)
 	if !ok {
 		return fmt.Errorf("build system driver does not support job-level watching")
@@ -144,6 +156,10 @@ func (w *Watcher) watchJobs(r *run.Run) error {
 				return fmt.Errorf("final refresh of run data: %w", err)
 			}
 			return nil
+		}
+
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for watched jobs to complete", w.Options.WatchTimeout)
 		}
 
 		time.Sleep(3 * time.Second)


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup
/kind feature

#### What this PR does / why we need it:

This commit modifies how tejolote discovers its own name by now using the runner name and status to avoid confusion when users defined a custom name for the job.

We also now add a timeout for the watcher to ensure tejolote does not run indefenitely in case it can't watch itself, this change is because I just ran out of my minutes when I left tejolote watching a Scala build :( :(

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- Improved the job name detection in the tejolote watcher
- Added --watch-timeout to control how long tejolote will poll running jobs (defaults to 20min)
```
