### PR TITLE
Add --expand-artifacts and --artifacts-filter to attest

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ artifacts produced after a run, Tejolote sits one level above and
 will expect artifacts to appear in the storage location(s) you
 tell it to monitor.
 
+### GitHub Actions artifacts
+
+When attesting a GitHub Actions run, Tejolote collects the run's uploaded
+artifacts automatically. Because the Actions API serves each artifact as a zip
+archive, Tejolote unpacks them by default and records one subject per contained
+file, hashed by its content and named by its path within the zip. Pass
+`--expand-artifacts=false` to attest each archive as a single subject instead.
+
+`--artifacts-filter` limits what gets attested from **any** source: pass a glob
+(`path.Match` syntax) matched against each artifact's name (the last element of
+its path). For GitHub Actions the match is applied to the artifact name before
+download; for other sources it is applied to the collected artifact names:
+
+```bash
+tejolote attest github://my-org/my-repo/12345 \
+   --artifacts-filter='release-*'
+```
+
 ## Example
 
 Let's say for example you want to attest a Cloud Build job that produces

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ archive, Tejolote unpacks them by default and records one subject per contained
 file, hashed by its content and named by its path within the zip. Pass
 `--expand-artifacts=false` to attest each archive as a single subject instead.
 
+If you pass one or more `--artifacts` sources, Tejolote collects only from those
+and skips the run's native artifacts — so you can point it at a directory of
+files you prepared yourself instead of the automatically-collected artifacts.
+
 `--artifacts-filter` limits what gets attested from **any** source: pass a glob
 (`path.Match` syntax) matched against each artifact's name (the last element of
 its path). For GitHub Actions the match is applied to the artifact name before

--- a/internal/cmd/attest.go
+++ b/internal/cmd/attest.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"slices"
 	"strings"
 
@@ -62,6 +63,14 @@ func (o *attestOptions) Verify() error {
 
 	if !slices.Contains(slsaVersions, o.slsaVersion) {
 		errs = append(errs, fmt.Errorf("invalid slsa versions must be one of %v", slsaVersions))
+	}
+
+	// Validate the artifacts filter glob up front so a bad pattern fails fast
+	// instead of surfacing only once artifacts are processed, minutes into a run.
+	if o.artifactsFilter != "" {
+		if _, err := path.Match(o.artifactsFilter, ""); err != nil {
+			errs = append(errs, fmt.Errorf("invalid artifacts filter %q: %w", o.artifactsFilter, err))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/internal/cmd/attest.go
+++ b/internal/cmd/attest.go
@@ -41,6 +41,8 @@ type attestOptions struct {
 	slsaVersion      string
 	artifacts        []string
 	watchJobs        []string
+	expandArtifacts  bool
+	artifactsFilter  string
 }
 
 const (
@@ -95,6 +97,16 @@ page of the organization/repository repository. We support other sources
 such as GCS buckets, OCI registries and so on. Check the docs for more
 info.
 
+GitHub Actions artifacts are downloaded as zip archives. By default tejolote
+unpacks them and records one subject per contained file, hashed by its content
+and named by its path within the zip. Pass --expand-artifacts=false to instead
+attest each archive as a single subject.
+
+Use --artifacts-filter to attest only a subset of the run's artifacts. The flag
+takes a glob (path.Match syntax) matched against the artifact names, for example:
+
+  tejolote attest github://org/repo/12345 --artifacts-filter='release-*'
+
 🔸 Dependency Data
 ------------------
 
@@ -146,6 +158,8 @@ build data and generates the provenance attestation.
 			w.Options.WaitForBuild = attestOpts.waitForBuild
 			w.Options.SLSAVersion = attestOpts.slsaVersion
 			w.Options.WatchJobs = attestOpts.watchJobs
+			w.Options.ExpandArtifacts = attestOpts.expandArtifacts
+			w.Options.ArtifactsFilter = attestOpts.artifactsFilter
 
 			// Auto detect if tejolote is running inside a GitHub Actions
 			// workflow and the spec URL points to the same run. The we automatically
@@ -282,6 +296,20 @@ build data and generates the provenance attestation.
 		"artifacts",
 		[]string{},
 		"a storage URL to monitor for files",
+	)
+
+	attestCmd.PersistentFlags().BoolVar(
+		&attestOpts.expandArtifacts,
+		"expand-artifacts",
+		true,
+		"unpack actions artifacts and attest each file, or attest archive when false",
+	)
+
+	attestCmd.PersistentFlags().StringVar(
+		&attestOpts.artifactsFilter,
+		"artifacts-filter",
+		"",
+		"only attest artifacts whose name matches this glob",
 	)
 	attestCmd.PersistentFlags().BoolVar(
 		&attestOpts.waitForBuild,

--- a/internal/cmd/attest.go
+++ b/internal/cmd/attest.go
@@ -97,6 +97,10 @@ page of the organization/repository repository. We support other sources
 such as GCS buckets, OCI registries and so on. Check the docs for more
 info.
 
+When you specify one or more --artifacts sources, tejolote collects only from
+those and skips the build system's native artifact store. With no --artifacts
+flag it collects the run's native artifacts automatically.
+
 GitHub Actions artifacts are downloaded as zip archives. By default tejolote
 unpacks them and records one subject per contained file, hashed by its content
 and named by its path within the zip. Pass --expand-artifacts=false to instead

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -49,7 +49,9 @@ type Step struct {
 
 // Artifact abstracts a file with the items we're interested in monitoring
 type Artifact struct {
-	Path     string
+	Path string
+	// URL, when set, locates the artifact and is recorded as the subject's uri.
+	URL      string
 	Checksum map[string]string
 	Time     time.Time
 }

--- a/pkg/store/driver/actions.go
+++ b/pkg/store/driver/actions.go
@@ -190,9 +190,11 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 }
 
 // hashArtifactZip unpacks a downloaded GitHub Actions artifact (always a zip)
-// and returns one subject per contained file, each hashed by its content and
-// named by its path within the zip. If the payload is not a valid zip it falls
-// back to hashing the raw blob as a single subject.
+// and returns one subject per contained file, each hashed by its content. Each
+// subject is named "<artifactName>/<path within the zip>" so files sharing a
+// name across different artifacts (e.g. checksums.txt) stay distinct, and its
+// uri points at the specific file inside the archive. If the payload is not a
+// valid zip it falls back to hashing the raw blob as a single subject.
 func hashArtifactZip(zipPath, artifactName, artifactURL string, updated time.Time) ([]run.Artifact, error) {
 	zr, err := zip.OpenReader(zipPath)
 	if err != nil {
@@ -220,14 +222,29 @@ func hashArtifactZip(zipPath, artifactName, artifactURL string, updated time.Tim
 		if herr != nil {
 			return nil, fmt.Errorf("hashing %s: %w", zf.Name, herr)
 		}
+		// Drop the leading slash so a hostile entry name (eg "../../x") cannot
+		// escape the artifact-name prefix
+		entry := strings.TrimPrefix(path.Clean("/"+zf.Name), "/")
 		subjects = append(subjects, run.Artifact{
-			Path:     zf.Name,
-			URL:      artifactURL,
+			Path:     artifactName + "/" + entry,
+			URL:      zipEntryURI(artifactURL, entry),
 			Checksum: map[string]string{string(intoto.AlgorithmSHA256): shaVal},
 			Time:     updated,
 		})
 	}
 	return subjects, nil
+}
+
+// zipEntryURI points an artifact's download URL at a specific file inside the
+// zip using the URL fragment, eg .../artifacts/42/zip#bin/tejolote. The entry
+// path is encoded so names with special characters are still a valid URI
+func zipEntryURI(artifactURL, entry string) string {
+	u, err := url.Parse(artifactURL)
+	if err != nil {
+		return artifactURL + "#" + entry
+	}
+	u.Fragment = entry
+	return u.String()
 }
 
 // maxZipEntrySize caps how many bytes tejolote will read and hash from a single

--- a/pkg/store/driver/actions.go
+++ b/pkg/store/driver/actions.go
@@ -17,15 +17,21 @@ limitations under the License.
 package driver
 
 import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/sirupsen/logrus"
@@ -43,6 +49,16 @@ type Actions struct {
 	Organization string
 	Repository   string
 	RunID        int
+
+	// Expand controls how artifacts are hashed. When true (the default) each
+	// artifact zip is unpacked and every contained file becomes its own subject,
+	// hashed by content. When false, the downloaded artifact archive is hashed
+	// as a single subject.
+	Expand bool
+
+	// Filter, when non-empty, is a glob (path.Match syntax) matched against
+	// artifact names; only matching artifacts are collected.
+	Filter string
 }
 
 var ErrNoWorkflowToken = errors.New("token does not have workflow scope")
@@ -65,6 +81,7 @@ func NewActions(specURL string) (*Actions, error) {
 		Organization: u.Hostname(),
 		Repository:   repo,
 		RunID:        runid,
+		Expand:       true,
 	}
 	return a, nil
 }
@@ -96,17 +113,34 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 		return nil, fmt.Errorf("unmarshalling GitHub response: %w", err)
 	}
 
-	// Now we need to download the artifacts to hash them
+	// Filter the artifacts by name (glob) if a filter is configured, so we only
+	// download and attest the ones we care about.
+	selected := make([]github.Artifact, 0, len(artifacts.Artifacts))
+	for _, art := range artifacts.Artifacts {
+		if a.Filter != "" {
+			match, err := path.Match(a.Filter, art.Name)
+			if err != nil {
+				return nil, fmt.Errorf("invalid artifacts filter %q: %w", a.Filter, err)
+			}
+			if !match {
+				logrus.Debugf("artifact %q does not match filter %q, skipping", art.Name, a.Filter)
+				continue
+			}
+		}
+		selected = append(selected, art)
+	}
+
+	// Download the selected artifacts to hash them.
 	tmpdir, err := os.MkdirTemp("", "artifacts-")
 	if err != nil {
 		return nil, fmt.Errorf("creating temp dir: %w", err)
 	}
 
 	// Create files and writers for parallel download
-	urls := make([]string, len(artifacts.Artifacts))
-	files := make([]*os.File, len(artifacts.Artifacts))
-	writers := make([]io.Writer, len(artifacts.Artifacts))
-	for i, art := range artifacts.Artifacts {
+	urls := make([]string, len(selected))
+	files := make([]*os.File, len(selected))
+	writers := make([]io.Writer, len(selected))
+	for i, art := range selected {
 		f, err := os.Create(filepath.Join(tmpdir, art.Name))
 		if err != nil {
 			return nil, fmt.Errorf("creating artifact file: %w", err)
@@ -124,23 +158,95 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 		return nil, fmt.Errorf("downloading artifacts: %w", err)
 	}
 
-	// Hash the downloaded files and build the result
-	ret := make([]run.Artifact, 0, len(artifacts.Artifacts))
-	for i, art := range artifacts.Artifacts {
+	// Each downloaded artifact is a ZIP archive (the GitHub Actions artifact
+	// download API always returns a zip wrapping the uploaded files). When Expand
+	// is set we unpack each one and emit a subject per contained file, hashed by
+	// its content and named by its path within the zip. Otherwise we hash the
+	// archive itself as a single subject named by the artifact.
+	ret := make([]run.Artifact, 0, len(selected))
+	for i, art := range selected {
+		if a.Expand {
+			subjects, err := hashArtifactZip(files[i].Name(), art.Name, art.UpdatedAt)
+			if err != nil {
+				return nil, fmt.Errorf("hashing artifact %q: %w", art.Name, err)
+			}
+			ret = append(ret, subjects...)
+			continue
+		}
+
 		shaVal, err := hash.SHA256ForFile(files[i].Name())
 		if err != nil {
-			return nil, fmt.Errorf("hashing file: %w", err)
+			return nil, fmt.Errorf("hashing artifact %q: %w", art.Name, err)
 		}
 		ret = append(ret, run.Artifact{
-			Path: runURL + "/" + art.Name,
-			Checksum: map[string]string{
-				string(intoto.AlgorithmSHA256): shaVal,
-			},
-			Time: art.UpdatedAt,
+			Path:     art.Name,
+			Checksum: map[string]string{string(intoto.AlgorithmSHA256): shaVal},
+			Time:     art.UpdatedAt,
 		})
 	}
-	logrus.Infof("%d artifacts collected from run %d", len(ret), a.RunID)
+	logrus.Infof("collected %d subjects from %d artifacts in run %d", len(ret), len(selected), a.RunID)
 	return ret, nil
+}
+
+// hashArtifactZip unpacks a downloaded GitHub Actions artifact (always a zip)
+// and returns one subject per contained file, each hashed by its content and
+// named by its path within the zip. If the payload is not a valid zip it falls
+// back to hashing the raw blob as a single subject.
+func hashArtifactZip(zipPath, artifactName string, updated time.Time) ([]run.Artifact, error) {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		// Not a zip (should not happen for Actions artifacts): hash the blob.
+		logrus.Warnf("artifact %q is not a zip archive, hashing raw blob: %v", artifactName, err)
+		shaVal, herr := hash.SHA256ForFile(zipPath)
+		if herr != nil {
+			return nil, herr
+		}
+		return []run.Artifact{{
+			Path:     artifactName,
+			Checksum: map[string]string{string(intoto.AlgorithmSHA256): shaVal},
+			Time:     updated,
+		}}, nil
+	}
+	defer zr.Close()
+
+	subjects := make([]run.Artifact, 0, len(zr.File))
+	for _, zf := range zr.File {
+		if zf.FileInfo().IsDir() {
+			continue
+		}
+		shaVal, herr := sha256ZipEntry(zf)
+		if herr != nil {
+			return nil, fmt.Errorf("hashing %s: %w", zf.Name, herr)
+		}
+		subjects = append(subjects, run.Artifact{
+			Path:     zf.Name,
+			Checksum: map[string]string{string(intoto.AlgorithmSHA256): shaVal},
+			Time:     updated,
+		})
+	}
+	return subjects, nil
+}
+
+// sha256ZipEntry returns the hex-encoded SHA256 of a zip entry's contents.
+func sha256ZipEntry(zf *zip.File) (string, error) {
+	rc, err := zf.Open()
+	if err != nil {
+		return "", fmt.Errorf("opening zip entry: %w", err)
+	}
+	defer rc.Close()
+
+	// Bound the copy to the entry's declared uncompressed size to guard against
+	// a decompression bomb (gosec G110).
+	size := zf.UncompressedSize64
+	if size > math.MaxInt64 {
+		return "", fmt.Errorf("zip entry %q declares an implausible size", zf.Name)
+	}
+
+	h := sha256.New()
+	if _, err := io.CopyN(h, rc, int64(size)); err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("reading zip entry: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // Snap returns a snapshot of the current state

--- a/pkg/store/driver/actions.go
+++ b/pkg/store/driver/actions.go
@@ -161,11 +161,12 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 	// download API always returns a zip wrapping the uploaded files). When Expand
 	// is set we unpack each one and emit a subject per contained file, hashed by
 	// its content and named by its path within the zip. Otherwise we hash the
-	// archive itself as a single subject named by the artifact.
+	// archive itself as a single subject, keeping the prior subject name (the
+	// artifacts API URL joined with the artifact name) for compatibility.
 	ret := make([]run.Artifact, 0, len(selected))
 	for i, art := range selected {
 		if a.Expand {
-			subjects, err := hashArtifactZip(files[i].Name(), art.Name, art.UpdatedAt)
+			subjects, err := hashArtifactZip(files[i].Name(), art.Name, art.URL, art.UpdatedAt)
 			if err != nil {
 				return nil, fmt.Errorf("hashing artifact %q: %w", art.Name, err)
 			}
@@ -178,7 +179,8 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 			return nil, fmt.Errorf("hashing artifact %q: %w", art.Name, err)
 		}
 		ret = append(ret, run.Artifact{
-			Path:     art.Name,
+			Path:     runURL + "/" + art.Name,
+			URL:      art.URL,
 			Checksum: map[string]string{string(intoto.AlgorithmSHA256): shaVal},
 			Time:     art.UpdatedAt,
 		})
@@ -191,7 +193,7 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 // and returns one subject per contained file, each hashed by its content and
 // named by its path within the zip. If the payload is not a valid zip it falls
 // back to hashing the raw blob as a single subject.
-func hashArtifactZip(zipPath, artifactName string, updated time.Time) ([]run.Artifact, error) {
+func hashArtifactZip(zipPath, artifactName, artifactURL string, updated time.Time) ([]run.Artifact, error) {
 	zr, err := zip.OpenReader(zipPath)
 	if err != nil {
 		// Not a zip (should not happen for Actions artifacts): hash the blob.
@@ -202,6 +204,7 @@ func hashArtifactZip(zipPath, artifactName string, updated time.Time) ([]run.Art
 		}
 		return []run.Artifact{{
 			Path:     artifactName,
+			URL:      artifactURL,
 			Checksum: map[string]string{string(intoto.AlgorithmSHA256): shaVal},
 			Time:     updated,
 		}}, nil
@@ -219,6 +222,7 @@ func hashArtifactZip(zipPath, artifactName string, updated time.Time) ([]run.Art
 		}
 		subjects = append(subjects, run.Artifact{
 			Path:     zf.Name,
+			URL:      artifactURL,
 			Checksum: map[string]string{string(intoto.AlgorithmSHA256): shaVal},
 			Time:     updated,
 		})

--- a/pkg/store/driver/actions.go
+++ b/pkg/store/driver/actions.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/url"
 	"os"
 	"path"
@@ -227,6 +226,11 @@ func hashArtifactZip(zipPath, artifactName string, updated time.Time) ([]run.Art
 	return subjects, nil
 }
 
+// maxZipEntrySize caps how many bytes tejolote will read and hash from a single
+// file inside a GitHub Actions artifact zip. Real artifacts are far smaller and
+// a larger declared size may be a decompression bomb
+const maxZipEntrySize = 10 << 30 // 10 GiB
+
 // sha256ZipEntry returns the hex-encoded SHA256 of a zip entry's contents.
 func sha256ZipEntry(zf *zip.File) (string, error) {
 	rc, err := zf.Open()
@@ -235,11 +239,14 @@ func sha256ZipEntry(zf *zip.File) (string, error) {
 	}
 	defer rc.Close()
 
-	// Bound the copy to the entry's declared uncompressed size to guard against
-	// a decompression bomb (gosec G110).
+	// Reject entries declaring a size larger than maxZipEntrySize and then only
+	// copy up to those bytes (gosec G110).
 	size := zf.UncompressedSize64
-	if size > math.MaxInt64 {
-		return "", fmt.Errorf("zip entry %q declares an implausible size", zf.Name)
+	if size > maxZipEntrySize {
+		return "", fmt.Errorf(
+			"zip entry %q declares uncompressed size %d bytes, exceeding the %d byte limit",
+			zf.Name, size, uint64(maxZipEntrySize),
+		)
 	}
 
 	h := sha256.New()

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -212,6 +212,7 @@ func (w *Watcher) AttestRun(r *run.Run) (att *attestation.Attestation, err error
 	for _, a := range r.Artifacts {
 		s := &intoto.ResourceDescriptor{
 			Name:   a.Path,
+			Uri:    a.URL,
 			Digest: map[string]string{},
 		}
 		maps.Copy(s.GetDigest(), a.Checksum)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -237,9 +237,15 @@ func (w *Watcher) AddArtifactSource(specURL string) error {
 // collects any artifacts found after the build is done
 func (w *Watcher) CollectArtifacts(r *run.Run) error {
 	r.Artifacts = nil
+
+	// If explicit artifact sources were configured (via --artifacts), collect
+	// only from those. Otherwise fall back to the build system's native artifact
+	// store (e.g. the run's GitHub Actions artifacts).
 	artifactStores := w.ArtifactStores
-	// TODO: Support disabling the native driver
-	artifactStores = append(artifactStores, w.Builder.ArtifactStores()...)
+	if len(artifactStores) == 0 {
+		artifactStores = append(artifactStores, w.Builder.ArtifactStores()...)
+	}
+
 	for _, s := range artifactStores {
 		// The GitHub Actions store filters and expands internally, before
 		// downloading, matching the filter against the artifact name. Other
@@ -268,7 +274,7 @@ func (w *Watcher) CollectArtifacts(r *run.Run) error {
 	}
 	logrus.Infof(
 		"Run produced %d artifacts collected from %d sources",
-		len(r.Artifacts), len(w.ArtifactStores),
+		len(r.Artifacts), len(artifactStores),
 	)
 	return nil
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"maps"
 	"os"
+	pathpkg "path"
 	"strings"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/tejolote/pkg/builder/driver"
 	"sigs.k8s.io/tejolote/pkg/run"
 	"sigs.k8s.io/tejolote/pkg/store"
+	storedriver "sigs.k8s.io/tejolote/pkg/store/driver"
 	"sigs.k8s.io/tejolote/pkg/store/snapshot"
 )
 
@@ -48,16 +50,19 @@ type Watcher struct {
 }
 
 type Options struct {
-	WaitForBuild bool     // When true, the watcher will keep observing the run until it's done
-	SLSAVersion  string   // SLSA version for the attestation predicate
-	WatchJobs    []string // When set, watch these specific jobs instead of the whole run
-	ExcludeJob   string   // Job name to exclude from watching (typically the attester's own job)
+	WaitForBuild    bool     // When true, the watcher will keep observing the run until it's done
+	SLSAVersion     string   // SLSA version for the attestation predicate
+	WatchJobs       []string // When set, watch these specific jobs instead of the whole run
+	ExcludeJob      string   // Job name to exclude from watching (typically the attester's own job)
+	ExpandArtifacts bool     // When true, unpack archive-wrapped artifacts (GitHub Actions) and hash contained files
+	ArtifactsFilter string   // When set, a glob matched against artifact names; only matching artifacts are collected
 }
 
 func New(uri string) (w *Watcher, err error) {
 	w = &Watcher{
 		Options: Options{
-			WaitForBuild: true, // By default we watch the build run
+			WaitForBuild:    true, // By default we watch the build run
+			ExpandArtifacts: true, // By default, unpack artifact archives and hash contained files
 		},
 	}
 
@@ -236,11 +241,29 @@ func (w *Watcher) CollectArtifacts(r *run.Run) error {
 	// TODO: Support disabling the native driver
 	artifactStores = append(artifactStores, w.Builder.ArtifactStores()...)
 	for _, s := range artifactStores {
+		// The GitHub Actions store filters and expands internally, before
+		// downloading, matching the filter against the artifact name. Other
+		// sources have no such structure, so we filter their results here.
+		filterHere := w.Options.ArtifactsFilter != ""
+		if act, ok := s.Driver.(*storedriver.Actions); ok {
+			act.Expand = w.Options.ExpandArtifacts
+			act.Filter = w.Options.ArtifactsFilter
+			filterHere = false
+		}
+
 		logrus.Infof("Collecting artifacts from %s", s.SpecURL)
 		artifacts, err := s.ReadArtifacts()
 		if err != nil {
 			return fmt.Errorf("collecting artfiacts from %s: %w", s.SpecURL, err)
 		}
+
+		if filterHere {
+			artifacts, err = filterArtifactsByName(artifacts, w.Options.ArtifactsFilter)
+			if err != nil {
+				return fmt.Errorf("filtering artifacts from %s: %w", s.SpecURL, err)
+			}
+		}
+
 		r.Artifacts = append(r.Artifacts, artifacts...)
 	}
 	logrus.Infof(
@@ -248,6 +271,28 @@ func (w *Watcher) CollectArtifacts(r *run.Run) error {
 		len(r.Artifacts), len(w.ArtifactStores),
 	)
 	return nil
+}
+
+// filterArtifactsByName keeps only the artifacts whose name — the last element
+// of their path — matches the given glob (path.Match syntax). An empty glob
+// keeps everything.
+func filterArtifactsByName(artifacts []run.Artifact, glob string) ([]run.Artifact, error) {
+	if glob == "" {
+		return artifacts, nil
+	}
+	out := make([]run.Artifact, 0, len(artifacts))
+	for _, a := range artifacts {
+		match, err := pathpkg.Match(glob, pathpkg.Base(a.Path))
+		if err != nil {
+			return nil, fmt.Errorf("invalid artifacts filter %q: %w", glob, err)
+		}
+		if !match {
+			logrus.Debugf("artifact %q does not match filter %q, skipping", a.Path, glob)
+			continue
+		}
+		out = append(out, a)
+	}
+	return out, nil
 }
 
 // Snap adds a new snapshot set to the watcher by querying


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR adds two new features to tejolote which were missing to control the subjects that end up in the attestation:

- `--expand-artifacts` we now correctly unpack and hash the contents of the actions artifact zips. If the user wants to attest the whole archive can still do so with  `--expand-artifacts=false` . Only applies to artifacts not the other sources (releases, GCS, etc)
- `--artifacts-filter` defines a glob to only add the matching artifacts as subjects in the attestation

I also piggybacked a bugfix where tejolote would not replace the default artifact collector when specifying other artifact sources.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
- New flag `--expand-artifacts` controls if tejolote attests the artifact zip contents or the archive itself
- `--artifacts-filter` allows the user to specify a glob to add only specific files to the attestation
```
