### PR TITLE
Bump golangci-lint to v2.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,5 +38,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11
+          version: v2.12
           args: --verbose

--- a/pkg/store/driver/github.go
+++ b/pkg/store/driver/github.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	intoto "github.com/in-toto/attestation/go/v1"
 	"sigs.k8s.io/release-sdk/github"
 	"sigs.k8s.io/release-utils/hash"
 	"sigs.k8s.io/tejolote/pkg/run"
@@ -115,7 +116,7 @@ func (ghr *GitHubRelease) Snap() (*snapshot.Snapshot, error) {
 		snap[filepath.Base(path)] = run.Artifact{
 			Path: filepath.Base(path),
 			Checksum: map[string]string{
-				"sha256": hashValue,
+				string(intoto.AlgorithmSHA256): hashValue,
 			},
 			Time: time.Now(), // TODO: This needs to be set properly for future
 		}

--- a/pkg/store/snapshot/snapshot_test.go
+++ b/pkg/store/snapshot/snapshot_test.go
@@ -25,19 +25,23 @@ import (
 )
 
 func TestDelta(t *testing.T) {
+	const (
+		testFileName = "test.txt"
+		sha256Key    = "sha256"
+	)
 	testFile := run.Artifact{
-		Path:     "test.txt",
-		Checksum: map[string]string{"sha256": "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"},
+		Path:     testFileName,
+		Checksum: map[string]string{sha256Key: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"},
 		Time:     time.Now(),
 	}
 	modHashFile := run.Artifact{
-		Path:     "test.txt",
-		Checksum: map[string]string{"sha256": "25b89320221dda5abe3df4624d246d22d0c820ee3598e97553611d7c80abbd36"},
+		Path:     testFileName,
+		Checksum: map[string]string{sha256Key: "25b89320221dda5abe3df4624d246d22d0c820ee3598e97553611d7c80abbd36"},
 		Time:     testFile.Time,
 	}
 	modTimeFile := run.Artifact{
-		Path:     "test.txt",
-		Checksum: map[string]string{"sha256": "25b89320221dda5abe3df4624d246d22d0c820ee3598e97553611d7c80abbd36"},
+		Path:     testFileName,
+		Checksum: map[string]string{sha256Key: "25b89320221dda5abe3df4624d246d22d0c820ee3598e97553611d7c80abbd36"},
 		Time:     time.Date(1976, time.Month(2), 10, 23, 30, 30, 0, time.Local),
 	}
 	for _, tc := range []struct {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR bumps golanci-lint in CI to v2.12 an fixes all the resulting nits

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?


```release-note
NONE
```
