### PR TITLE
Support multiple glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,18 @@ If you pass one or more `--artifacts` sources, Tejolote collects only from those
 and skips the run's native artifacts — so you can point it at a directory of
 files you prepared yourself instead of the automatically-collected artifacts.
 
-`--artifacts-filter` limits what gets attested from **any** source: pass a glob
-(`path.Match` syntax) matched against each artifact's name (the last element of
-its path). For GitHub Actions the match is applied to the artifact name before
-download; for other sources it is applied to the collected artifact names:
+`--artifacts-filter` limits what gets attested from the artifacts source: pass
+one or more globs ([`path.Match` syntax](https://pkg.go.dev/path#Match)) matched
+against each artifact's base name (the last element of its path). Any artifacts
+matching any of the globs are attested (added to the statement's subject). Repeat
+the flag or pass a comma-separated list. For GitHub Actions, the match is applied
+to the artifact name before download, all other sources it is applied to the
+collected artifact names:
 
 ```bash
 tejolote attest github://my-org/my-repo/12345 \
-   --artifacts-filter='release-*'
+   --artifacts-filter='release-*' \
+   --artifacts-filter='*.sbom'
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ one or more globs ([`path.Match` syntax](https://pkg.go.dev/path#Match)) matched
 against each artifact's base name (the last element of its path). Any artifacts
 matching any of the globs are attested (added to the statement's subject). Repeat
 the flag or pass a comma-separated list. For GitHub Actions, the match is applied
-to the artifact name before download, all other sources it is applied to the
+to the artifact name before download; for all other sources, it is applied to the
 collected artifact names:
 
 ```bash

--- a/internal/cmd/attest.go
+++ b/internal/cmd/attest.go
@@ -46,7 +46,7 @@ type attestOptions struct {
 	artifacts        []string
 	watchJobs        []string
 	expandArtifacts  bool
-	artifactsFilter  string
+	artifactsFilter  []string
 	envelope         string
 	watchTimeout     time.Duration
 }
@@ -74,11 +74,11 @@ func (o *attestOptions) Verify() error {
 		errs = append(errs, fmt.Errorf("invalid slsa versions must be one of %v", slsaVersions))
 	}
 
-	// Validate the artifacts filter glob up front so a bad pattern fails fast
+	// Validate the artifacts filter globs up front so a bad pattern fails fast
 	// instead of surfacing only once artifacts are processed, minutes into a run.
-	if o.artifactsFilter != "" {
-		if _, err := path.Match(o.artifactsFilter, ""); err != nil {
-			errs = append(errs, fmt.Errorf("invalid artifacts filter %q: %w", o.artifactsFilter, err))
+	for _, glob := range o.artifactsFilter {
+		if _, err := path.Match(glob, ""); err != nil {
+			errs = append(errs, fmt.Errorf("invalid artifacts filter %q: %w", glob, err))
 		}
 	}
 
@@ -129,9 +129,12 @@ and named by its path within the zip. Pass --expand-artifacts=false to instead
 attest each archive as a single subject.
 
 Use --artifacts-filter to attest only a subset of the run's artifacts. The flag
-takes a glob (path.Match syntax) matched against the artifact names, for example:
+takes one or more globs (path.Match syntax) matched against the artifact names;
+artifacts matching any of the globs are attested. Repeat the flag or pass a
+comma-separated list, for example:
 
-  tejolote attest github://org/repo/12345 --artifacts-filter='release-*'
+  tejolote attest github://org/repo/12345 \
+    --artifacts-filter='release-*' --artifacts-filter='*.sbom'
 
 🔸 Dependency Data
 ------------------
@@ -354,11 +357,11 @@ build data and generates the provenance attestation.
 		"unpack actions artifacts and attest each file, or attest archive when false",
 	)
 
-	attestCmd.PersistentFlags().StringVar(
+	attestCmd.PersistentFlags().StringSliceVar(
 		&attestOpts.artifactsFilter,
 		"artifacts-filter",
-		"",
-		"only attest artifacts whose name matches this glob",
+		[]string{},
+		"only attest artifacts whose name matches one of these globs (can be repeated)",
 	)
 	attestCmd.PersistentFlags().BoolVar(
 		&attestOpts.waitForBuild,

--- a/pkg/store/driver/actions.go
+++ b/pkg/store/driver/actions.go
@@ -55,12 +55,31 @@ type Actions struct {
 	// as a single subject.
 	Expand bool
 
-	// Filter, when non-empty, is a glob (path.Match syntax) matched against
-	// artifact names; only matching artifacts are collected.
-	Filter string
+	// Filter, when non-empty, is a list of globs (path.Match syntax) matched
+	// against artifact names; only artifacts matching at least one glob are
+	// collected.
+	Filter []string
 }
 
 var ErrNoWorkflowToken = errors.New("token does not have workflow scope")
+
+// matchesFilter reports whether an artifact name matches at least one of the
+// configured filter globs. An empty filter matches everything.
+func (a *Actions) matchesFilter(name string) (bool, error) {
+	if len(a.Filter) == 0 {
+		return true, nil
+	}
+	for _, glob := range a.Filter {
+		match, err := path.Match(glob, name)
+		if err != nil {
+			return false, fmt.Errorf("invalid artifacts filter %q: %w", glob, err)
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 func NewActions(specURL string) (*Actions, error) {
 	u, err := url.Parse(specURL)
@@ -112,19 +131,17 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 		return nil, fmt.Errorf("unmarshalling GitHub response: %w", err)
 	}
 
-	// Filter the artifacts by name (glob) if a filter is configured, so we only
+	// Filter the artifacts by name (globs) if a filter is configured, so we only
 	// download and attest the ones we care about.
 	selected := make([]github.Artifact, 0, len(artifacts.Artifacts))
 	for _, art := range artifacts.Artifacts {
-		if a.Filter != "" {
-			match, err := path.Match(a.Filter, art.Name)
-			if err != nil {
-				return nil, fmt.Errorf("invalid artifacts filter %q: %w", a.Filter, err)
-			}
-			if !match {
-				logrus.Debugf("artifact %q does not match filter %q, skipping", art.Name, a.Filter)
-				continue
-			}
+		match, err := a.matchesFilter(art.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !match {
+			logrus.Debugf("artifact %q does not match filters %v, skipping", art.Name, a.Filter)
+			continue
 		}
 		selected = append(selected, art)
 	}

--- a/pkg/store/driver/actions.go
+++ b/pkg/store/driver/actions.go
@@ -69,7 +69,13 @@ func (a *Actions) matchesFilter(name string) (bool, error) {
 	if len(a.Filter) == 0 {
 		return true, nil
 	}
-	for _, glob := range a.Filter {
+	return MatchesAnyGlob(a.Filter, name)
+}
+
+// MatchesAnyGlob reports whether name matches at least one of the globs
+// (path.Match syntax).
+func MatchesAnyGlob(globs []string, name string) (bool, error) {
+	for _, glob := range globs {
 		match, err := path.Match(glob, name)
 		if err != nil {
 			return false, fmt.Errorf("invalid artifacts filter %q: %w", glob, err)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -309,7 +309,7 @@ func filterArtifactsByName(artifacts []run.Artifact, globs []string) ([]run.Arti
 	}
 	out := make([]run.Artifact, 0, len(artifacts))
 	for _, a := range artifacts {
-		match, err := matchesAnyGlob(globs, pathpkg.Base(a.Path))
+		match, err := storedriver.MatchesAnyGlob(globs, pathpkg.Base(a.Path))
 		if err != nil {
 			return nil, err
 		}
@@ -320,21 +320,6 @@ func filterArtifactsByName(artifacts []run.Artifact, globs []string) ([]run.Arti
 		out = append(out, a)
 	}
 	return out, nil
-}
-
-// matchesAnyGlob reports whether name matches at least one of the globs
-// (path.Match syntax).
-func matchesAnyGlob(globs []string, name string) (bool, error) {
-	for _, glob := range globs {
-		match, err := pathpkg.Match(glob, name)
-		if err != nil {
-			return false, fmt.Errorf("invalid artifacts filter %q: %w", glob, err)
-		}
-		if match {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // Snap adds a new snapshot set to the watcher by querying

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -55,7 +55,7 @@ type Options struct {
 	WatchJobs       []string      // When set, watch these specific jobs instead of the whole run
 	ExcludeJob      string        // Job name to exclude from watching (typically the attester's own job)
 	ExpandArtifacts bool          // When true, unpack archive-wrapped artifacts (GitHub Actions) and hash contained files
-	ArtifactsFilter string        // When set, a glob matched against artifact names; only matching artifacts are collected
+	ArtifactsFilter []string      // When set, globs matched against artifact names; only artifacts matching at least one are collected
 	WatchTimeout    time.Duration // Max time to wait for the run/jobs to complete (0 = no timeout)
 }
 
@@ -269,9 +269,9 @@ func (w *Watcher) CollectArtifacts(r *run.Run) error {
 
 	for _, s := range artifactStores {
 		// The GitHub Actions store filters and expands internally, before
-		// downloading, matching the filter against the artifact name. Other
+		// downloading, matching the filters against the artifact name. Other
 		// sources have no such structure, so we filter their results here.
-		filterHere := w.Options.ArtifactsFilter != ""
+		filterHere := len(w.Options.ArtifactsFilter) > 0
 		if act, ok := s.Driver.(*storedriver.Actions); ok {
 			act.Expand = w.Options.ExpandArtifacts
 			act.Filter = w.Options.ArtifactsFilter
@@ -301,25 +301,40 @@ func (w *Watcher) CollectArtifacts(r *run.Run) error {
 }
 
 // filterArtifactsByName keeps only the artifacts whose name — the last element
-// of their path — matches the given glob (path.Match syntax). An empty glob
-// keeps everything.
-func filterArtifactsByName(artifacts []run.Artifact, glob string) ([]run.Artifact, error) {
-	if glob == "" {
+// of their path — matches at least one of the given globs (path.Match syntax).
+// An empty glob list keeps everything.
+func filterArtifactsByName(artifacts []run.Artifact, globs []string) ([]run.Artifact, error) {
+	if len(globs) == 0 {
 		return artifacts, nil
 	}
 	out := make([]run.Artifact, 0, len(artifacts))
 	for _, a := range artifacts {
-		match, err := pathpkg.Match(glob, pathpkg.Base(a.Path))
+		match, err := matchesAnyGlob(globs, pathpkg.Base(a.Path))
 		if err != nil {
-			return nil, fmt.Errorf("invalid artifacts filter %q: %w", glob, err)
+			return nil, err
 		}
 		if !match {
-			logrus.Debugf("artifact %q does not match filter %q, skipping", a.Path, glob)
+			logrus.Debugf("artifact %q does not match filters %v, skipping", a.Path, globs)
 			continue
 		}
 		out = append(out, a)
 	}
 	return out, nil
+}
+
+// matchesAnyGlob reports whether name matches at least one of the globs
+// (path.Match syntax).
+func matchesAnyGlob(globs []string, name string) (bool, error) {
+	for _, glob := range globs {
+		match, err := pathpkg.Match(glob, name)
+		if err != nil {
+			return false, fmt.Errorf("invalid artifacts filter %q: %w", glob, err)
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // Snap adds a new snapshot set to the watcher by querying

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -15,3 +15,68 @@ limitations under the License.
 */
 
 package watcher
+
+import (
+	"testing"
+
+	"sigs.k8s.io/tejolote/pkg/run"
+)
+
+func TestFilterArtifactsByName(t *testing.T) {
+	const (
+		amd64Tarball = "release-amd64.tar.gz"
+		arm64Tarball = "release-arm64.tar.gz"
+		sbom         = "dist/bom.spdx"
+		logFile      = "debug.log"
+		releaseGlob  = "release-*"
+	)
+	artifacts := []run.Artifact{
+		{Path: amd64Tarball},
+		{Path: arm64Tarball},
+		{Path: sbom},
+		{Path: logFile},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		globs     []string
+		expected  []string
+		shouldErr bool
+	}{
+		{name: "no globs keeps everything", globs: nil, expected: []string{
+			amd64Tarball, arm64Tarball, sbom, logFile,
+		}},
+		{name: "single glob", globs: []string{releaseGlob}, expected: []string{
+			amd64Tarball, arm64Tarball,
+		}},
+		{name: "multiple globs match any", globs: []string{releaseGlob, "*.spdx"}, expected: []string{
+			amd64Tarball, arm64Tarball, sbom,
+		}},
+		{name: "glob matches base name not full path", globs: []string{"bom.*"}, expected: []string{
+			sbom,
+		}},
+		{name: "no matches", globs: []string{"nothing-*"}, expected: []string{}},
+		{name: "invalid glob errors", globs: []string{releaseGlob, "[bad"}, shouldErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := filterArtifactsByName(artifacts, tc.globs)
+			if tc.shouldErr {
+				if err == nil {
+					t.Fatal("expected error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(res) != len(tc.expected) {
+				t.Fatalf("expected %d artifacts, got %d: %+v", len(tc.expected), len(res), res)
+			}
+			for i, a := range res {
+				if a.Path != tc.expected[i] {
+					t.Errorf("artifact #%d: expected %q, got %q", i, tc.expected[i], a.Path)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR allows for more than one glob when when specifying which artifacts to attest.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Tejolote now supports more than one glob by repeating `--artifacts-filter`
```
