### PR TITLE
Use go-github v90 client and methods

### DIFF
--- a/pkg/builder/driver/github.go
+++ b/pkg/builder/driver/github.go
@@ -17,11 +17,8 @@ limitations under the License.
 package driver
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -35,8 +32,6 @@ import (
 	"sigs.k8s.io/tejolote/pkg/run"
 	"sigs.k8s.io/tejolote/pkg/store"
 )
-
-const ghRunURL string = "https://api.github.com/repos/%s/%s/actions/runs/%d"
 
 type GitHubWorkflow struct {
 	Organization string
@@ -95,26 +90,9 @@ func (ghw *GitHubWorkflow) RefreshRun(r *run.Run) error {
 	ghw.Repository = repo
 	ghw.RunID = int(id)
 
-	res, err := github.APIGetRequest(fmt.Sprintf(ghRunURL, ghw.Organization, ghw.Repository, ghw.RunID))
+	runData, err := github.GetRun(ghw.Organization, ghw.Repository, int64(ghw.RunID))
 	if err != nil {
 		return fmt.Errorf("querying github api: %w", err)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("got https error %d from github API", res.StatusCode)
-	}
-
-	rawData, err := io.ReadAll(res.Body)
-	defer res.Body.Close()
-	if err != nil {
-		return fmt.Errorf("reading api response data: %w", err)
-	}
-
-	logrus.Debugf("Rawdata: %s", string(rawData))
-
-	runData := &github.Run{}
-	if err := json.Unmarshal(rawData, runData); err != nil {
-		return fmt.Errorf("unmarshalling GitHub response: %w", err)
 	}
 
 	if runData.Status == "completed" {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -18,13 +18,13 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	gogithub "github.com/google/go-github/v90/github"
@@ -32,15 +32,32 @@ import (
 	khttp "sigs.k8s.io/release-utils/http"
 )
 
+// itemsPerPage is the page size used when reading paginated API listings.
+const itemsPerPage = 100
+
+// defaultClient returns the client shared by this package, built on first use.
+// Note that the GITHUB_TOKEN value is captured on first use and reused for the
+// lifetime of the process, later changes to the environment have no effect.
+var defaultClient = sync.OnceValues(NewClient)
+
 // TokenScopes returns the scopes of token in the eviroment
 func TokenScopes() ([]string, error) {
-	res, err := APIGetRequest("https://api.github.com/repos/github/docs")
+	client, err := defaultClient()
+	if err != nil {
+		return nil, fmt.Errorf("creating github client: %w", err)
+	}
+
+	// Any authenticated request echoes the token scopes back in a header
+	_, res, err := client.Repositories.Get(context.Background(), "github", "docs")
 	if err != nil {
 		return nil, fmt.Errorf("making request to API: %w", err)
 	}
-	defer res.Body.Close()
 
 	header := res.Header.Get("X-Oauth-Scopes")
+	if header == "" {
+		return []string{}, nil
+	}
+
 	scopes := strings.Split(header, ", ")
 	logrus.Debugf("GitHub Token scopes: %+v", scopes)
 	return scopes, nil
@@ -60,54 +77,87 @@ func TokenHas(scope string) (bool, error) {
 	return false, nil
 }
 
-func APIGetRequest(url string) (*http.Response, error) {
-	logrus.Debugf("GitHubAPI[GET]: %s", url)
-	client := &http.Client{}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+// GetRun fetches the data of a workflow run.
+//
+// The response is read into tejolote's own run type instead of go-github's:
+// the provenance predicate is built from fields the API returns but the
+// go-github type does not model, such as the workflow_dispatch inputs.
+func GetRun(org, repo string, runID int64) (*Run, error) {
+	client, err := defaultClient()
 	if err != nil {
-		return nil, fmt.Errorf("creating http request: %w", err)
+		return nil, fmt.Errorf("creating github client: %w", err)
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	if os.Getenv("GITHUB_TOKEN") != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("token %s", os.Getenv("GITHUB_TOKEN")))
-	} else {
-		logrus.Warn("making unauthenticated request to github")
-	}
-	res, err := client.Do(req)
+
+	req, err := client.NewRequest(
+		context.Background(), http.MethodGet,
+		fmt.Sprintf("repos/%s/%s/actions/runs/%d", org, repo, runID), nil,
+	)
 	if err != nil {
-		return res, fmt.Errorf("executing http request to GitHub API: %w", err)
+		return nil, fmt.Errorf("building run request: %w", err)
 	}
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(
-			"http error %d making request to GitHub API", res.StatusCode,
-		)
+
+	runData := &Run{}
+	if _, err := client.Do(req, runData); err != nil {
+		return nil, fmt.Errorf("querying run API: %w", err)
 	}
-	return res, nil
+	return runData, nil
 }
 
 // GetRunJobs fetches the jobs for a given workflow run from the GitHub API.
 func GetRunJobs(org, repo string, runID int64) ([]*gogithub.WorkflowJob, error) {
-	u := fmt.Sprintf(
-		"https://api.github.com/repos/%s/%s/actions/runs/%d/jobs",
-		org, repo, runID,
-	)
-	res, err := APIGetRequest(u)
+	client, err := defaultClient()
 	if err != nil {
-		return nil, fmt.Errorf("querying jobs API: %w", err)
+		return nil, fmt.Errorf("creating github client: %w", err)
 	}
-	defer res.Body.Close()
 
-	rawData, err := io.ReadAll(res.Body)
+	ctx := context.Background()
+	opts := &gogithub.ListWorkflowJobsOptions{
+		ListOptions: gogithub.ListOptions{PerPage: itemsPerPage},
+	}
+
+	jobs := []*gogithub.WorkflowJob{}
+	for {
+		page, res, err := client.Actions.ListWorkflowJobs(ctx, org, repo, runID, opts)
+		if err != nil {
+			return nil, fmt.Errorf("querying jobs API: %w", err)
+		}
+
+		jobs = append(jobs, page.Jobs...)
+		if res.NextPage == 0 {
+			break
+		}
+		opts.Page = res.NextPage
+	}
+
+	return jobs, nil
+}
+
+// ListRunArtifacts returns the artifacts a workflow run stored in the GitHub
+// Actions artifact store.
+func ListRunArtifacts(org, repo string, runID int64) ([]*gogithub.Artifact, error) {
+	client, err := defaultClient()
 	if err != nil {
-		return nil, fmt.Errorf("reading jobs response: %w", err)
+		return nil, fmt.Errorf("creating github client: %w", err)
 	}
 
-	var jobsResp gogithub.Jobs
-	if err := json.Unmarshal(rawData, &jobsResp); err != nil {
-		return nil, fmt.Errorf("unmarshalling jobs response: %w", err)
+	ctx := context.Background()
+	opts := &gogithub.ListOptions{PerPage: itemsPerPage}
+
+	artifacts := []*gogithub.Artifact{}
+	for {
+		page, res, err := client.Actions.ListWorkflowRunArtifacts(ctx, org, repo, runID, opts)
+		if err != nil {
+			return nil, fmt.Errorf("querying artifacts API: %w", err)
+		}
+
+		artifacts = append(artifacts, page.Artifacts...)
+		if res.NextPage == 0 {
+			break
+		}
+		opts.Page = res.NextPage
 	}
 
-	return jobsResp.Jobs, nil
+	return artifacts, nil
 }
 
 // GetCurrentJob returns the WorkflowJob for the job currently executing inside a

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -18,16 +18,6 @@ package github
 
 import "time"
 
-// Artifact is the artifact structure returned by the API
-type Artifact struct {
-	ID        int       `json:"id"`
-	Name      string    `json:"name"`
-	Size      int       `json:"size_in_bytes"`
-	URL       string    `json:"archive_download_url"`
-	Expired   bool      `json:"expired"`
-	UpdatedAt time.Time `json:"updated_at"`
-}
-
 type Run struct {
 	ID              int64             `json:"id"`
 	Status          string            `json:"status"`

--- a/pkg/github/workflow.go
+++ b/pkg/github/workflow.go
@@ -17,17 +17,12 @@ limitations under the License.
 package github
 
 import (
-	"encoding/base64"
-	"encoding/json"
+	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 
+	gogithub "github.com/google/go-github/v90/github"
 	"sigs.k8s.io/yaml"
 )
-
-var ghContentsURL = "https://api.github.com/repos/%s/%s/contents/%s?ref=%s"
 
 // WorkflowInput represents a single input defined in a workflow YAML.
 type WorkflowInput struct {
@@ -86,47 +81,31 @@ func (wd *WorkflowData) JobKeys() []string {
 	return keys
 }
 
-// contentsResponse represents the GitHub contents API response.
-type contentsResponse struct {
-	Content  string `json:"content"`
-	Encoding string `json:"encoding"`
-}
-
 // FetchWorkflow fetches and parses a workflow YAML from the GitHub contents API.
 func FetchWorkflow(org, repo, path, ref string) (*WorkflowData, error) {
-	apiURL := fmt.Sprintf(ghContentsURL, org, repo, url.PathEscape(path), url.QueryEscape(ref))
+	client, err := defaultClient()
+	if err != nil {
+		return nil, fmt.Errorf("creating github client: %w", err)
+	}
 
-	res, err := APIGetRequest(apiURL)
+	fileContent, _, _, err := client.Repositories.GetContents(
+		context.Background(), org, repo, path,
+		&gogithub.RepositoryContentGetOptions{Ref: ref},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("fetching workflow file: %w", err)
 	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("got HTTP %d fetching workflow file", res.StatusCode)
+	if fileContent == nil {
+		return nil, fmt.Errorf("%s is not a file in %s/%s", path, org, repo)
 	}
 
-	rawData, err := io.ReadAll(res.Body)
+	yamlData, err := fileContent.GetContent()
 	if err != nil {
-		return nil, fmt.Errorf("reading workflow contents response: %w", err)
-	}
-
-	var cr contentsResponse
-	if err := json.Unmarshal(rawData, &cr); err != nil {
-		return nil, fmt.Errorf("unmarshalling contents response: %w", err)
-	}
-
-	if cr.Encoding != "base64" {
-		return nil, fmt.Errorf("unexpected content encoding %q", cr.Encoding)
-	}
-
-	yamlData, err := base64.StdEncoding.DecodeString(cr.Content)
-	if err != nil {
-		return nil, fmt.Errorf("decoding base64 content: %w", err)
+		return nil, fmt.Errorf("decoding workflow contents: %w", err)
 	}
 
 	var wf WorkflowData
-	if err := yaml.Unmarshal(yamlData, &wf); err != nil {
+	if err := yaml.Unmarshal([]byte(yamlData), &wf); err != nil {
 		return nil, fmt.Errorf("parsing workflow YAML: %w", err)
 	}
 

--- a/pkg/github/workflow_test.go
+++ b/pkg/github/workflow_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	gogithub "github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,24 +81,29 @@ on:
         type: string
 `
 	encoded := base64.StdEncoding.EncodeToString([]byte(workflowYAML))
-	resp := contentsResponse{Content: encoded, Encoding: "base64"}
-	respJSON, err := json.Marshal(resp)
+	respJSON, err := json.Marshal(gogithub.RepositoryContent{
+		Type:     gogithub.Ptr("file"),
+		Path:     gogithub.Ptr(".github/workflows/release.yml"),
+		Content:  gogithub.Ptr(encoded),
+		Encoding: gogithub.Ptr("base64"),
+	})
 	require.NoError(t, err)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(respJSON)
 	}))
 	defer server.Close()
 
-	// Override the API URL by setting up the test server
-	origURL := ghContentsURL
-	ghContentsURL = server.URL + "/%s/%s/%s?ref=%s"
-	defer func() { ghContentsURL = origURL }()
+	// Point the package client at the test server, whose handler answers
+	// regardless of the path go-github builds
+	client, err := gogithub.NewClient(gogithub.WithEnterpriseURLs(server.URL, server.URL))
+	require.NoError(t, err)
 
-	// Set GITHUB_TOKEN to avoid auth warnings in tests
-	t.Setenv("GITHUB_TOKEN", "test-token")
+	origClient := defaultClient
+	defaultClient = func() (*gogithub.Client, error) { return client, nil }
+	defer func() { defaultClient = origClient }()
 
 	inputs, err := FetchWorkflowInputs("org", "repo", ".github/workflows/release.yml", "abc123")
 	require.NoError(t, err)

--- a/pkg/store/driver/actions.go
+++ b/pkg/store/driver/actions.go
@@ -20,7 +20,6 @@ import (
 	"archive/zip"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -32,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	gogithub "github.com/google/go-github/v90/github"
 	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/release-utils/hash"
@@ -40,9 +40,9 @@ import (
 	"sigs.k8s.io/tejolote/pkg/store/snapshot"
 )
 
+// actionsArtifactsURL names the run's artifact listing. It is only used to
+// build the subject paths, the listing itself goes through the API client.
 const actionsArtifactsURL = "https://api.github.com/repos/%s/%s/actions/runs/%d/artifacts"
-
-// const actionsArtifactsURL =    "https://api.github.com/repos/%s/%s/actions/artifacts/%d"
 
 type Actions struct {
 	Organization string
@@ -117,36 +117,21 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 		a.Organization, a.Repository, a.RunID,
 	)
 
-	res, err := github.APIGetRequest(runURL)
+	artifacts, err := github.ListRunArtifacts(a.Organization, a.Repository, int64(a.RunID))
 	if err != nil {
 		return nil, fmt.Errorf("querying GitHub api for artifacts: %w", err)
-	}
-	rawData, err := io.ReadAll(res.Body)
-	defer res.Body.Close()
-	if err != nil {
-		return nil, fmt.Errorf("reading api response data: %w", err)
-	}
-
-	artifacts := struct {
-		Artifacts []github.Artifact `json:"artifacts"`
-	}{
-		Artifacts: []github.Artifact{},
-	}
-
-	if err := json.Unmarshal(rawData, &artifacts); err != nil {
-		return nil, fmt.Errorf("unmarshalling GitHub response: %w", err)
 	}
 
 	// Filter the artifacts by name (globs) if a filter is configured, so we only
 	// download and attest the ones we care about.
-	selected := make([]github.Artifact, 0, len(artifacts.Artifacts))
-	for _, art := range artifacts.Artifacts {
-		match, err := a.matchesFilter(art.Name)
+	selected := make([]*gogithub.Artifact, 0, len(artifacts))
+	for _, art := range artifacts {
+		match, err := a.matchesFilter(art.GetName())
 		if err != nil {
 			return nil, err
 		}
 		if !match {
-			logrus.Debugf("artifact %q does not match filters %v, skipping", art.Name, a.Filter)
+			logrus.Debugf("artifact %q does not match filters %v, skipping", art.GetName(), a.Filter)
 			continue
 		}
 		selected = append(selected, art)
@@ -163,12 +148,12 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 	files := make([]*os.File, len(selected))
 	writers := make([]io.Writer, len(selected))
 	for i, art := range selected {
-		f, err := os.Create(filepath.Join(tmpdir, art.Name))
+		f, err := os.Create(filepath.Join(tmpdir, art.GetName()))
 		if err != nil {
 			return nil, fmt.Errorf("creating artifact file: %w", err)
 		}
 		defer f.Close()
-		urls[i] = art.URL
+		urls[i] = art.GetArchiveDownloadURL()
 		files[i] = f
 		writers[i] = f
 	}
@@ -189,9 +174,11 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 	ret := make([]run.Artifact, 0, len(selected))
 	for i, art := range selected {
 		if a.Expand {
-			subjects, err := hashArtifactZip(files[i].Name(), art.Name, art.URL, art.UpdatedAt)
+			subjects, err := hashArtifactZip(
+				files[i].Name(), art.GetName(), art.GetArchiveDownloadURL(), art.GetUpdatedAt().Time,
+			)
 			if err != nil {
-				return nil, fmt.Errorf("hashing artifact %q: %w", art.Name, err)
+				return nil, fmt.Errorf("hashing artifact %q: %w", art.GetName(), err)
 			}
 			ret = append(ret, subjects...)
 			continue
@@ -199,13 +186,13 @@ func (a *Actions) readArtifacts() ([]run.Artifact, error) {
 
 		shaVal, err := hash.SHA256ForFile(files[i].Name())
 		if err != nil {
-			return nil, fmt.Errorf("hashing artifact %q: %w", art.Name, err)
+			return nil, fmt.Errorf("hashing artifact %q: %w", art.GetName(), err)
 		}
 		ret = append(ret, run.Artifact{
-			Path:     runURL + "/" + art.Name,
-			URL:      art.URL,
+			Path:     runURL + "/" + art.GetName(),
+			URL:      art.GetArchiveDownloadURL(),
 			Checksum: map[string]string{string(intoto.AlgorithmSHA256): shaVal},
-			Time:     art.UpdatedAt,
+			Time:     art.GetUpdatedAt().Time,
 		})
 	}
 	logrus.Infof("collected %d subjects from %d artifacts in run %d", len(ret), len(selected), a.RunID)


### PR DESCRIPTION
When we initially wrote tejolote, go-github didn't have methods 

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When we initially wrote tejolote, go-github was missing a various methods types and a proper method to call the API.

After bumping go-github to v90 in #681, this PR follow up and  updates the github calls to use the methods from the go -github library whenever possible instead of calling net/http directly and implemeting our own types.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Needs #681 and a rebase

#### Does this PR introduce a user-facing change?

```release-note
Tejolote now uses modern (v90) go-github methods and types instead of its own implementations
```
